### PR TITLE
avoid usage of date(1)

### DIFF
--- a/pg_dumpbinary
+++ b/pg_dumpbinary
@@ -18,6 +18,7 @@ use File::Spec qw/ tmpdir /;
 use File::Temp qw/ tempfile /;
 use DBI;
 use DBD::Pg;
+use DateTime;
 
 my $VERSION = '1.0';
 my $PROGRAM = 'pg_dumpbinary';
@@ -168,7 +169,7 @@ if (!-d $OUTDIR)
 	mkdir $OUTDIR or die "FATAL: can not create directory $OUTDIR, $!\n";
 }
 
-print "Database $DBNAME dump created at ", `date --rfc-3339=seconds`;
+print "Database $DBNAME dump created at ", get_current_date();
 
 # Set DBD::Pg options and connect to the database
 # to create the snapshot for a consistent backup
@@ -332,7 +333,7 @@ $dbh->disconnect;
 
 exit(1) if ($interrupt);
 
-print "Dump ended at ", `date --rfc-3339=seconds`;
+print "Dump ended at ", get_current_date();
 
 exit 0;
 
@@ -397,15 +398,14 @@ sub get_table_list
 }
 
 ####
-# Return the date in ISO 8601 format minus the timezone part
+# Return the date in ISO 8601 format minus the timezone part.
+# As an example of returned value: 2019-09-03T09:03:12
 ####
 sub get_current_date
 {
-	my $curdate = `date -Iseconds`;
-	chomp($curdate);
-	$curdate =~ s/[+-]\d{2}:\d{2}$//;
-
-	return $curdate;
+    my $curdate = DateTime->now( time_zone =>
+                                 DateTime::TimeZone->new( name => 'local' ) );
+    return $curdate->strftime( '%FT%T' );
 }
 
 ####

--- a/pg_dumpbinary
+++ b/pg_dumpbinary
@@ -169,7 +169,7 @@ if (!-d $OUTDIR)
 	mkdir $OUTDIR or die "FATAL: can not create directory $OUTDIR, $!\n";
 }
 
-print "Database $DBNAME dump created at ", get_current_date();
+printf "Database $DBNAME dump created at %s\n", get_current_date();
 
 # Set DBD::Pg options and connect to the database
 # to create the snapshot for a consistent backup
@@ -333,7 +333,7 @@ $dbh->disconnect;
 
 exit(1) if ($interrupt);
 
-print "Dump ended at ", get_current_date();
+printf "Dump ended at %s\n", get_current_date();
 
 exit 0;
 

--- a/pg_dumpbinary
+++ b/pg_dumpbinary
@@ -403,8 +403,13 @@ sub get_table_list
 ####
 sub get_current_date
 {
-    my $curdate = DateTime->now( time_zone =>
-                                 DateTime::TimeZone->new( name => 'local' ) );
+    my $tz;
+    eval { $tz = DateTime::TimeZone->new( name => 'local' ); };
+    if ( $@ ) {
+        print "WARNING: cannot determine local timezone, using UTC\n";
+        $tz = DateTime::TimeZone->new( name => 'UTC' );
+    }
+    my $curdate = DateTime->now( time_zone => $tz );
     return $curdate->strftime( '%FT%T' );
 }
 


### PR DESCRIPTION
I think the program should use Perl internal modules to determine times instead of invoking `date(1)`. In particular, on FreeBSD, the program is broken because of a slightly different `date(1)` syntax.

I've used `DateTime` to format dates. One problem is about timezone, that could not be determined by Perl, so UTC is used as a default.